### PR TITLE
fix: top damager placeholders don't reset per mob [EcoHub-130]

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/mob/damage/TopDamagers.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/mob/damage/TopDamagers.kt
@@ -26,6 +26,9 @@ data class Damager(
 private const val metaKey = "TOP_DAMAGERS"
 
 class TopDamagerHandler(private val plugin: EcoMobsPlugin) : Listener {
+    private val places: Int
+        get() = plugin.configYml.getInt("top-damager-places")
+
     @Suppress("UNCHECKED_CAST")
     private var Mob.topDamagers: List<Damager>
         get() = (this.getMetadata(metaKey).getOrNull(0)?.value() as? List<Damager>) ?: emptyList()
@@ -63,22 +66,26 @@ class TopDamagerHandler(private val plugin: EcoMobsPlugin) : Listener {
     }
 
     fun generatePlaceholders(mob: Mob): List<NamedValue> {
-        return mob.topDamagers
-            .flatMapIndexed { index, damager ->
-                listOf(
-                    NamedValue(
-                        "top_damager_${index + 1}_name",
-                        Bukkit.getOfflinePlayer(damager.uuid).name ?: "Unknown"
-                    ),
-                    NamedValue(
-                        "top_damager_${index + 1}_display",
-                        Bukkit.getOfflinePlayer(damager.uuid).savedDisplayName
-                    ),
-                    NamedValue(
-                        "top_damager_${index + 1}_damage",
-                        damager.damage.toNiceString()
-                    )
+        val topDamagers = mob.topDamagers
+
+        return (0 until places).flatMap { index ->
+            val damager = topDamagers.getOrNull(index)
+            val offlinePlayer = damager?.let { Bukkit.getOfflinePlayer(it.uuid) }
+
+            listOf(
+                NamedValue(
+                    "top_damager_${index + 1}_name",
+                    if (damager == null) "" else offlinePlayer?.name ?: "Unknown"
+                ),
+                NamedValue(
+                    "top_damager_${index + 1}_display",
+                    if (damager == null) "" else offlinePlayer?.savedDisplayName ?: "Unknown"
+                ),
+                NamedValue(
+                    "top_damager_${index + 1}_damage",
+                    damager?.damage?.toNiceString() ?: "0"
                 )
-            }
+            )
+        }
     }
 }

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -5,6 +5,9 @@
 
 discover-recipes: true
 
+# The number of places to generate %top_damager_<place>_...% placeholders for
+top-damager-places: 10
+
 custom-spawning:
   # The spawn rate is the number of ticks to wait between trying to spawn a mob.
   # 20 ticks = 1 second; the higher the number, the less often mobs will spawn.

--- a/ecohub/ecomobs/how-to-make-a-custom-mob.md
+++ b/ecohub/ecomobs/how-to-make-a-custom-mob.md
@@ -399,9 +399,11 @@ These placeholders work in the `display-name` and in effects on this mob.
 | `%max_hits%` | The hits the current stage takes (`0` outside a `hits` stage) |
 | `%hits_percent%` | The percentage of the current stage's hits left (`100` outside a `hits` stage) |
 | `%time%` | The time left before the mob despawns (`minutes:seconds`) |
-| `%top_damager_<place>_name%` | The name of the [0-9] top damager |
-| `%top_damager_<place>_damage%` | The damage dealt by the [0-9] top damager, counting one per hit during a `hits` stage |
-| `%top_damager_<place>_display%` | The ranking of the [0-9] top damager |
+| `%top_damager_<place>_name%` | The name of the top damager in that place (empty if nobody placed there) |
+| `%top_damager_<place>_damage%` | The damage dealt by the top damager in that place, counting one per hit during a `hits` stage (`0` if nobody placed there) |
+| `%top_damager_<place>_display%` | The display name of the top damager in that place (empty if nobody placed there) |
+
+The number of places is set by `top-damager-places` in `config.yml`, and defaults to 10.
 
 :::tip Troubleshooting
 - **Mob won't load?** Check the ID rules above; the file name must be lowercase letters, numbers, and underscores only.


### PR DESCRIPTION
<img width="661" height="34" alt="{DEE90320-9824-43EE-A218-F702EBE7AD3F}" src="https://github.com/user-attachments/assets/7c5d95be-1e97-48b8-b6bf-b82de787e869" />
<img width="598" height="32" alt="{4B8D2E1C-6C41-4435-B2F9-7A0C1101E81A}" src="https://github.com/user-attachments/assets/cadef969-ecf4-47db-ada1-b3d319cca776" />
<img width="582" height="27" alt="{D115C404-FB76-4357-AA67-BCBD1417DDD7}" src="https://github.com/user-attachments/assets/20ef1bbf-c4a0-430b-8ced-d183a6326908" />
